### PR TITLE
build: avoid python referencing same env lists across different prope…

### DIFF
--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -884,10 +884,13 @@ class Meson (Build, ModifyEnvBase) :
         props['objc_args'] = build_env.pop('OBJCFLAGS', [])
         props['objcpp_args'] = build_env.pop('OBJCXXFLAGS', [])
         # Link args
-        props['c_link_args'] = build_env.pop('LDFLAGS', [])
-        props['cpp_link_args'] = props['c_link_args']
-        props['objc_link_args'] = build_env.pop('OBJLDFLAGS', props['c_link_args'])
-        props['objcpp_link_args'] = props['objc_link_args']
+        ldflags_value = build_env.pop('LDFLAGS', [])
+        props['c_link_args'] = ldflags_value.copy()
+        props['cpp_link_args'] = ldflags_value.copy()
+        objldflags_value = build_env.pop('OBJLDFLAGS', ldflags_value)
+        props['objc_link_args'] = objldflags_value.copy()
+        props['objcpp_link_args'] = objldflags_value.copy()
+
         for key, value in self.config.meson_properties.items():
             if key not in props:
                 props[key] = value


### PR DESCRIPTION
…rty values

When constructing C and C++ link argument lists, retrieve the LDFLAGS or
OBJLDFLAGS values from the build_env and then explicitly copy them into the
props dictionary. This should avoid Python using references to these list
objects inside the dictionary, with the same referenced lists then getting
updated with different additional meson configuration entries.