### PR TITLE
wpewebkit: bump to version 2.34.6

### DIFF
--- a/packages/wpewebkit-core.package
+++ b/packages/wpewebkit-core.package
@@ -7,7 +7,7 @@ import os
 
 class Package(package.Package):
     name = 'wpewebkit-core'
-    version = '2.34.1'
+    version = '2.34.6'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/packages/wpewebkit.package
+++ b/packages/wpewebkit.package
@@ -2,7 +2,7 @@
 
 class SDKPackage(package.SDKPackage):
     name = 'wpewebkit'
-    version = '2.34.1'
+    version = '2.34.6'
     shortdesc = 'Web Platform for Embedded'
     longdesc = 'WPE WebKit allows embedders to create simple and performant \
         systems based on Web platform technologies. It is a WebKit port designed \

--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -4,11 +4,11 @@ from cerbero.utils import android, shell
 
 class Recipe(recipe.Recipe):
     name = 'wpewebkit'
-    version = '2.34.1'
+    version = '2.34.6'
     stype = SourceType.TARBALL
     btype = BuildType.CMAKE
     url = 'https://wpewebkit.org/releases/wpewebkit-{0}.tar.xz'.format(version)
-    tarball_checksum = 'cb336986341be9c3a9b1ca2c18de0d29d90ae4e77b9967a6f6879597e7a969f7'
+    tarball_checksum = '301e895c8ed08ce7dccef3192b972f2ccfc2020463244c64069a636f2b05265f'
     deps = [
         'icu',
         'cairo',


### PR DESCRIPTION
Update the `wpewebkit` build recipe and packaging definitions to version 2.34.6, which is the most recent in the series. This brings in a number of fixes and security fixes. Android-specific patches apply cleanly and do not need updating.