### PR TITLE
Remove absolute path from libWPEInjectedBundle.so location on Android

### DIFF
--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -192,6 +192,7 @@ class Recipe(recipe.Recipe):
                 'wpewebkit/0005-Android-terminate-process.patch',
                 'wpewebkit/0006-Implement-Android-WebProcess-and-NetworkProcess-entr.patch',
                 'wpewebkit/0007-Scroll-related-changes.patch',
+                'wpewebkit/0008-Remove-absolute-path-from-libWPEInjectedBundle.so-on.patch',
             ]
         else:
             self.append_env('LDFLAGS', '-lrt')

--- a/recipes/wpewebkit/0008-Remove-absolute-path-from-libWPEInjectedBundle.so-on.patch
+++ b/recipes/wpewebkit/0008-Remove-absolute-path-from-libWPEInjectedBundle.so-on.patch
@@ -1,0 +1,27 @@
+From 26b5a5035953a8fcfa93c37342596f79ee7d2509 Mon Sep 17 00:00:00 2001
+From: Jani Hautakangas <jani@igalia.com>
+Date: Thu, 24 Mar 2022 09:41:17 +0200
+Subject: [PATCH] Remove absolute path from libWPEInjectedBundle.so on Android
+
+Android application native library dir doesn't support subdirectories
+---
+ Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+index 990e8d04..7178e313 100644
+--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
++++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+@@ -323,8 +323,7 @@ static const char* injectedBundleDirectory()
+         G_DIR_SEPARATOR_S "injected-bundle" G_DIR_SEPARATOR_S;
+     return injectedBundlePath;
+ #elif PLATFORM(WPE)
+-    static const char* injectedBundlePath = PKGLIBDIR G_DIR_SEPARATOR_S "injected-bundle" G_DIR_SEPARATOR_S;
+-    return injectedBundlePath;
++    return "";
+ #endif
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Android application native library dir doesn't support subdirectories.
Also PKGLIBDIR in cerbero build points to development environment sysroot