### PR TITLE
Tweak configuration and recipes to enable ARMv7 builds

### DIFF
--- a/config/android.config
+++ b/config/android.config
@@ -132,8 +132,6 @@ if target_arch != Architecture.UNIVERSAL and not os.path.exists(lib_dir):
 # from android-ndk-r16/build/core/toolchains/$NAME-$VERSION/setup.mk
 ccache = use_ccache and 'ccache ' or ''
 defines = '-DANDROID -DPIC -D__ANDROID_API__=%s ' % (v)
-# -fno-integrated-as cause some libraries (e.g. pixman) fail to build with
-# clang's assembler
 # -target is being duplicated here and in CC variable to workaround cmake
 # ignoring arguments in CC while other build systems may ignore CFLAGS for
 # certain checks.
@@ -148,7 +146,7 @@ ldflags = '-fPIC -no-canonical-prefixes -Wl,-no-undefined -Wl,-z,noexecstack -Wl
 
 if target_arch == Architecture.ARMv7:
     defines += ' -D__ARM_ARCH_7A__ '
-    cflags += ' -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16'
+    cflags += ' -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=neon'
     ldflags += ' -Wl,--fix-cortex-a8 '
 elif target_arch == Architecture.X86:
     cflags += ' -march=i686 '
@@ -173,9 +171,6 @@ if v < 21:
     stl_cxxflags += ' -Wl,' + os.path.join (lib_dir, 'libandroid_support.a')
     stl_cxxlinkargs += ['-Wl,' + os.path.join (lib_dir, 'libandroid_support.a')]
     stl_cxxflags += ' -isystem ' + os.path.join (toolchain_prefix, 'sources', 'android', 'support', 'include')
-if target_arch == Architecture.ARMv7:
-    stl_cxxflags += ' -Wl,' + os.path.join (lib_dir, 'libunwind.a')
-    stl_cxxlinkargs += ['-Wl,' + os.path.join (lib_dir, 'libunwind.a')]
 
 # Toolchain environment
 env['CPPFLAGS'] = defines

--- a/config/cross-android-armv7.cbc
+++ b/config/cross-android-armv7.cbc
@@ -3,7 +3,7 @@ from cerbero.config import Platform, Architecture, Distro, DistroVersion
 
 target_platform = Platform.ANDROID
 target_distro = Distro.ANDROID
-target_distro_version = DistroVersion.ANDROID_LOLLIPOP
+target_distro_version = DistroVersion.ANDROID_OREO
 target_arch = Architecture.ARMv7
 
 variants.override('nodebug')

--- a/recipes/gettext.recipe
+++ b/recipes/gettext.recipe
@@ -1,7 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
 
-from cerbero.utils import android
-
 class Recipe(recipe.Recipe):
     name = 'gettext'
     version = '0.21'
@@ -15,7 +13,4 @@ class Recipe(recipe.Recipe):
     def prepare (self):
         if self.config.target_platform in (Platform.ANDROID):
             self.deps += ['libiconv']
-            arch_name = android.get_android_arch_name(self.config.target_arch)
-            stl_libdir = os.path.join(self.config.toolchain_prefix, 'libs', arch_name)
-            self.append_env('LDFLAGS', '-L' + stl_libdir, '-lc++_shared')
-
+            self.append_env('LDFLAGS', '-lc++_shared')

--- a/recipes/gnustl.recipe
+++ b/recipes/gnustl.recipe
@@ -24,7 +24,6 @@ class Recipe(recipe.Recipe):
     def prepare(self):
         if self.config.target_platform != Platform.ANDROID:
             raise InvalidRecipeError(self, "Invalid platform")
-        v = DistroVersion.get_android_api_version(self.config.target_distro_version)
 
     async def compile(self):
         libdir = os.path.join(self.config.prefix, 'lib')
@@ -32,11 +31,8 @@ class Recipe(recipe.Recipe):
             os.makedirs(libdir)
 
         # Generate libraries that aren't copied from the NDK
-        v = DistroVersion.get_android_api_version(self.config.target_distro_version)
-        if v >= 21:
+        if self.config.target_arch in (Architecture.X86_64, Architecture.ARM64):
             shell.new_call([self.get_env('AR'), 'rc', os.path.join(libdir, 'libandroid_support.a')], env=self.env)
-        if self.config.target_arch != Architecture.ARMv7:
-            shell.new_call([self.get_env('AR'), 'rc', os.path.join(libdir, 'libunwind.a')], env=self.env)
 
     async def install(self):
         stl_prefix = os.path.join(self.config.toolchain_prefix, 'sources',
@@ -50,14 +46,11 @@ class Recipe(recipe.Recipe):
         # Copies libraries to the prefix
         shutil.copy(os.path.join(stl_libdir, 'libc++_shared.so'),
                     os.path.join(libdir, 'libc++_shared.so'))
-        v = DistroVersion.get_android_api_version(self.config.target_distro_version)
-        if v < 21:
+
+        use_android_support = self.config.target_arch not in (Architecture.X86_64, Architecture.ARM64)
+        if use_android_support:
             shutil.copy(os.path.join(stl_libdir, 'libandroid_support.a'),
                         os.path.join(libdir, 'libandroid_support.a'))
-
-        if self.config.target_arch == Architecture.ARMv7:
-            shutil.copy(os.path.join(stl_libdir, 'libunwind.a'),
-                        os.path.join(libdir, 'libunwind.a'))
 
         # Create a libtool library for gnustl (libgnustl.la)
         lib = LibtoolLibrary('gnustl', None, None, None, libdir,
@@ -66,8 +59,7 @@ class Recipe(recipe.Recipe):
         lib.change_value('library_names', 'libc++_shared.so libc++_shared.so libc++_shared.so')
         lib.change_value('old_library', '')
         lib.change_value('dependency_libs', '-lc++_shared -lm' +
-                                (' %s/libandroid_support.a' % (libdir) if v < 21 else '') +
-                                (' %s/libunwind.a' % (libdir) if self.config.target_arch == Architecture.ARMv7 else ''))
+                                (' %s/libandroid_support.a' % (libdir) if use_android_support else ''))
         lib.save()
 
         # Create pkg-config file (gnustl.pc)
@@ -77,8 +69,7 @@ class Recipe(recipe.Recipe):
         stl_pc = PkgConfigWritter('gnustl', 'gnustl', '2.0',
                 '', '-L${libdir} ${libdir}/libc++_shared.so' +
                 (' %s/libm.so' % self.config.sysroot) +
-                (' ${libdir}/libandroid_support.a ' if v < 21 else '') +
-                (' ${libdir}/libunwind.a ' if self.config.target_arch == Architecture.ARMv7 else '') +
+                (' ${libdir}/libandroid_support.a ' if use_android_support else '') +
                 '',
                 '',
                 self.config.prefix)

--- a/recipes/gnutls.recipe
+++ b/recipes/gnutls.recipe
@@ -44,15 +44,6 @@ class Recipe(recipe.Recipe):
         if self.config.target_platform == Platform.ANDROID:
             self.configure_options += ' --disable-cxx'
             self.files_libs.remove('libgnutlsxx')
-            # Fix build with NDK 16
-            self.set_env('ac_cv_header_stdatomic_h', 'no')
-            v = DistroVersion.get_android_api_version(self.config.target_distro_version)
-            if self.config.target_arch in [Architecture.ARM, Architecture.ARMv7, Architecture.X86] and v < 21:
-                # FIXME: HACK to make projects compile with NDK 16
-                # we fail to compile with -D_FILE_OFFSET_BITS=64
-                # because we don't use clang and we use a platform < 21 (Lollipop)
-                # See $NDK_ROOT/sysroot/usr/include/sys/mman.h as one example
-                self.set_env('ac_cv_func_mmap', 'no')
         if self.config.target_platform == Platform.IOS:
             if self.config.target_arch == Architecture.ARM64:
                 self.configure_options += ' --disable-hardware-acceleration'
@@ -66,11 +57,6 @@ class Recipe(recipe.Recipe):
             # Edit configure.ac and not configure because we autoreconf later.
             shell.replace(os.path.join(self.build_dir, 'configure.ac'),
                           {'getentropy': 'getentropy_DISABLED_NOT_FOR_MACOS10_12'})
-        if self.config.target_platform == Platform.ANDROID:
-            # On Android, SIZE_MAX is define under limits.h
-            shell.replace(os.path.join(self.build_dir, 'gl', 'read-file.c'),
-                {'#include <stdint.h>':
-                 '#include <limits.h>'})
         # Call configure from the base class
         await super(recipe.Recipe, self).configure()
 

--- a/recipes/libgpg-error.recipe
+++ b/recipes/libgpg-error.recipe
@@ -22,7 +22,7 @@ class Recipe(recipe.Recipe):
         if self.config.cross_compiling():
             if self.config.target_arch == Architecture.ARM64:
                 cfg_file = 'lock-obj-pub.aarch64-unknown-linux-gnu.h'
-            elif self.config.target_arch == Architecture.ARM:
+            elif self.config.target_arch in (Architecture.ARM, Architecture.ARMv7):
                 cfg_file = 'lock-obj-pub.arm-unknown-linux-androideabi.h'
             else:
                 raise FatalError('Unsupported target arch: ' + self.config.target_arch)

--- a/recipes/pixman.recipe
+++ b/recipes/pixman.recipe
@@ -33,6 +33,8 @@ class Recipe(recipe.Recipe):
         if self.config.target_platform in [ Platform.DARWIN, Platform.IOS ] and \
            self.config.target_arch in [ Architecture.X86, Architecture.X86_64 ]:
             self.meson_options['mmx'] = 'disabled'
+        elif self.config.target_arch == Architecture.ARMv7:
+            self.meson_options['neon'] = 'enabled'
         if self.config.target_platform == Platform.IOS:
             self.append_env('CFLAGS', '-DPIXMAN_NO_TLS')
         if self.config.target_platform == Platform.ANDROID:
@@ -49,6 +51,9 @@ class Recipe(recipe.Recipe):
                 '-Dandroid_getCpuIdArm=pixman_android_getCpuIdArm',
                 '-Dandroid_setCpu=pixman_android_setCpu',
                 '-Dandroid_setCpuArm=pixman_android_setCpuArm')
+            if self.config.target_arch == Architecture.ARMv7:
+                self.append_env('CFLAGS', '-fno-integrated-as -fno-unwind-tables')
+                self.append_env('LDFLAGS', '-lm')
 
     def post_install(self):
         pixman_deps = []


### PR DESCRIPTION
Enable ARMv7 builds, with a combo of fixes:

- There were some leftovers in `configs/android.config` which needed tweaking after the update to NDK version r23b.
- Switched the API level used in ARMv7 builds to 26 (Oreo, needed for `AHardwareBuffer`).
- Use `-fno-integrated-as` for Pixman, to workaround its usage of assembler features not supported by the Clang/LLVM ARM assembler.
- Switch to `-mfpu=neon` for ARMv7, according to [the documentation](https://developer.android.com/ndk/guides/cpu-arm-neon) it should be enabled by default since NDK r21 and all reasonable devices should support it. Conversely, enable the `neon` option in the Pixman recipe.

This should take care of the part of https://github.com/Igalia/wpe-android/issues/10 related to creating bootstrap packages; but more followup work is needed to get the glue code and Minibrowser APK built. 