### PR TITLE
Enable builds targeting x86 and x86_64

### DIFF
--- a/config/android.config
+++ b/config/android.config
@@ -8,19 +8,15 @@ from cerbero.enums import Architecture, DistroVersion, Platform
 from cerbero.errors import FatalError
 import cerbero.utils.messages as m
 
-# So, paths:
+# The platforms and sysroot directories have been removed in NDK r22.
+# These directories were merged and relocated into the toolchain during r19.
+# The location of these contents should not be relevant to anyone,
+# including build systems, since the toolchain handles them implicitly.
+# It is not necessary anymore to explicitly set the sysroot include and libs directories
+# because Clang will automatically select the sysroot.
+# https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md
 #
-# With NDK r16, 'Unified Headers' is the only way to build against the NDK and
-# the API-level specific headers are not shipped anymore.  A migration guide is
-# available from https://android.googlesource.com/platform/ndk/+/ndk-release-r16/docs/UnifiedHeaders.md
-# and we follow that when setting up these paths.  One thing to note however
-# is that the 'Unified Headers' ship headers that contain API-level guarded
-# functions so we may need to replace or override headers.  One such example
-# is iconv.h which at the time of writing, has a header in the NDK
-# with no usable functions.  This simply means that we have to construct 
-# cflags/cppflags/ldflags/etc to look in our directories before looking into
-# the sysroot.
-#
+# These paths can be used by other recipes:
 # toolchain_prefix: NDK location
 # toolchain_path: location of the compiler binaries
 # sysroot: location of the API-level libraries (no headers)
@@ -49,7 +45,7 @@ if target_arch == Architecture.ARMv7:
     tools_dir = tools_prefix
     arch_include = tools_prefix
     host = 'arm-linux-androideabi'
-    llvm_triple = 'armv7-none-linux-androideabi' + str(v)
+    llvm_triple = 'armv7-none-linux-androideabi'
     _android_arch = 'arm'
     _cerbero_arch = 'armv7'
     _cxx_arch = 'armeabi-v7a'
@@ -89,6 +85,9 @@ elif target_arch == Architecture.UNIVERSAL:
 else:
   raise FatalError("Arch %s not supported" % target_arch)
 
+# https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#target-selection
+ndk_target = '%s%s' % (llvm_triple, v)
+
 if platform == Platform.DARWIN:
     tc_arch = 'darwin-x86_64'
 elif platform == Platform.LINUX:
@@ -101,9 +100,8 @@ spirv_toolchain_path = '%s/shader-tools/%s' % (toolchain_prefix, tc_arch)
 
 gcc_toolchain_path = os.path.join (gcc_toolchain_root, 'bin')
 
-isysroot = "%s/sysroot" % (gcc_toolchain_root)
-unversioned_sysroot = "%s/usr/lib/%s" % (isysroot, tools_prefix)
-sysroot = "%s/%d" % (unversioned_sysroot, v)
+isysroot = "%s/toolchains/llvm/prebuilt/%s/sysroot" % (toolchain_prefix, tc_arch)
+sysroot = "%s/usr/lib/%s/%s" % (isysroot, tools_prefix, v)
 
 # Default compiler flags
 env['CFLAGS'] = ''
@@ -135,7 +133,7 @@ defines = '-DANDROID -DPIC -D__ANDROID_API__=%s ' % (v)
 # -target is being duplicated here and in CC variable to workaround cmake
 # ignoring arguments in CC while other build systems may ignore CFLAGS for
 # certain checks.
-cflags = '-target %s --sysroot %s -gcc-toolchain %s -isysroot %s -isystem %s -isystem %s/usr/include -isystem %s/usr/include/%s -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fPIC -Wno-invalid-command-line-argument -Wno-unused-command-line-argument ' % (llvm_triple, sysroot, gcc_toolchain_root, isysroot, incl_dir, isysroot, isysroot, tools_prefix)
+cflags = '-target %s -isystem %s -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fPIC -Wno-invalid-command-line-argument -Wno-unused-command-line-argument ' % (ndk_target, incl_dir)
 
 # http://b.android.com/220159 http://b.android.com/222239
 if target_arch == Architecture.X86:
@@ -155,10 +153,6 @@ ldflags += ' -L%s' % (lib_dir,)
 if not target_arch in [Architecture.ARM64, Architecture.X86_64]:
    # nocopyreloc causes broken linking on arm64
    ldflags += ' -Wl,-z,nocopyreloc '
-if target_arch in [Architecture.X86_64]:
-   ldflags += ' -L%s/usr/lib64 ' % sysroot
-else:
-   ldflags += ' -L%s -B%s -Wc,-B%s ' % (sysroot, sysroot, sysroot)
 
 # this C++ stl setup is closely tied to the gnustl recipe which sets up the
 # necessary environment and files for this
@@ -166,11 +160,10 @@ stl_prefix = os.path.join(toolchain_prefix, 'sources', 'cxx-stl', 'llvm-libc++')
 stl_libdir = os.path.join(toolchain_prefix, 'libs', _cxx_arch)
 
 stl_cxxlinkargs = ['-nostdlib++', '-L' + stl_libdir, '-lc++_shared']
-stl_cxxflags = '-nostdlib++ -isystem ' + os.path.join (stl_prefix, 'include') + ' -isystem ' + os.path.join (stl_prefix, '..', 'llvm-libc++abi', 'include')
+stl_cxxflags = '-nostdlib++'
 if v < 21:
     stl_cxxflags += ' -Wl,' + os.path.join (lib_dir, 'libandroid_support.a')
     stl_cxxlinkargs += ['-Wl,' + os.path.join (lib_dir, 'libandroid_support.a')]
-    stl_cxxflags += ' -isystem ' + os.path.join (toolchain_prefix, 'sources', 'android', 'support', 'include')
 
 # Toolchain environment
 env['CPPFLAGS'] = defines
@@ -178,30 +171,23 @@ env['CFLAGS'] += "%s %s -Wa,--noexecstack" % (cflags, defines)
 env['CXXFLAGS'] = stl_cxxflags + ' ' + env['CFLAGS'] + ' -fno-rtti -fno-exceptions '
 env['LDFLAGS'] = ldflags
 
-def cmd(command):
-    return '%s-%s' % (tools_prefix, command)
-def llvm_cmd(command):
-    return 'llvm-%s' % (command)
+def llvm_bin(name):
+    return '%s/llvm-%s' % (llvm_toolchain_path, name)
 
 # clang requires the full path otherwise it does stupid things and can't
 # find it's own binary
-env['CC']= ccache + os.path.join(llvm_toolchain_path, 'clang-12') + ' -target %s%d' % (tools_prefix, v) + ' --sysroot %s' % (sysroot)
-env['CXX']= ccache + os.path.join(llvm_toolchain_path, 'clang-12') + ' -target %s%d' % (tools_prefix, v) + ' --sysroot %s' % (sysroot)
+env['CC']= ccache + os.path.join(llvm_toolchain_path, 'clang') + ' -target ' + ndk_target
+env['CXX']= ccache + os.path.join(llvm_toolchain_path, 'clang++') + ' -target ' + ndk_target
 env['LD']= os.path.join(llvm_toolchain_path, 'ld')
-env['CPP']= os.path.join(llvm_toolchain_path, 'clang-12') + ' -E'
-env['RANLIB']= llvm_cmd('ar') + ' s'
-env['AR']= llvm_cmd('ar')
-env['AS']= os.path.join(llvm_toolchain_path, '%s-as' % (tools_prefix))
-env['NM']= llvm_cmd('nm')
-env['STRIP']= llvm_cmd('strip')
-env['OBJCOPY']= llvm_cmd('objcopy')
+env['CPP']= os.path.join(llvm_toolchain_path, 'clang') + ' -E'
+env['RANLIB']= llvm_bin('ar') + ' s'
+env['AR']= llvm_bin('ar')
+env['AS']= os.path.join(llvm_toolchain_path, tools_prefix + '-as')
+env['NM']= llvm_bin('nm')
+env['STRIP']= llvm_bin('strip')
+env['OBJCOPY']= llvm_bin('objcopy')
 
 env['PATH'] = '%s:%s:%s:%s:%s' % (toolchain_prefix, llvm_toolchain_path, gcc_toolchain_path, spirv_toolchain_path, env['PATH'])
-# For the libc.so dependency in i686-linux-android-as
-if target_arch == Architecture.X86:
-    extra_lib_path = '%s/usr/lib' % (sysroot)
-elif target_arch == Architecture.X86_64:
-    extra_lib_path = '%s/usr/lib64' % (sysroot)
 
 # For GLib
 meson_properties['growing_stack'] = 'true'

--- a/config/cross-android-x86-64.cbc
+++ b/config/cross-android-x86-64.cbc
@@ -3,7 +3,7 @@ from cerbero.config import Platform, Architecture, Distro, DistroVersion
 
 target_platform = Platform.ANDROID
 target_distro = Distro.ANDROID
-target_distro_version = DistroVersion.ANDROID_LOLLIPOP
+target_distro_version = DistroVersion.ANDROID_OREO
 target_arch = Architecture.X86_64
 
 #variants.override('nodebug')

--- a/config/cross-android-x86.cbc
+++ b/config/cross-android-x86.cbc
@@ -3,7 +3,7 @@ from cerbero.config import Platform, Architecture, Distro, DistroVersion
 
 target_platform = Platform.ANDROID
 target_distro = Distro.ANDROID
-target_distro_version = DistroVersion.ANDROID_JELLY_BEAN
+target_distro_version = DistroVersion.ANDROID_OREO
 target_arch = Architecture.X86
 
 #variants.override('nodebug')

--- a/recipes/build-tools/meson.recipe
+++ b/recipes/build-tools/meson.recipe
@@ -23,10 +23,16 @@ class Recipe(recipe.Recipe):
             prefix = str(PurePath(self.config.prefix))
         else:
             prefix = self.config.prefix
-        await shell.async_call([self.config.python_exe, 'setup.py', 'install', '--prefix', prefix],
-                       cmd_dir=self.build_dir, env=self.env, logfile=self.logfile)
-        if self.config.platform == Platform.WINDOWS:
-            prefix = Path(self.config.prefix)
-            for f in ('meson.exe', 'meson-script.py'):
-                (prefix / 'Scripts' / f).replace(prefix / 'bin' / f)
-            shutil.rmtree(prefix / 'Scripts')
+        # Some distros have changed the default sysconfig scheme to
+        # manually add 'local' to all install dirs for setuptools.
+        # Reverting this is far too much work and will be fragile as heck,
+        # so just accept it and move on.
+        # Fedora: https://src.fedoraproject.org/rpms/python3.10/blob/f36/f/00251-change-user-install-location.patch
+        # Debian: https://salsa.debian.org/cpython-team/python3/-/blob/3.10.4-4/debian/patches/sysconfig-debian-schemes.diff
+        #
+        # Our workaround is to only install the script into bin. This also
+        # fixes things on Windows, where the script is installed into Scripts/
+        # instead of bin/
+        await shell.async_call([self.config.python_exe, 'setup.py', 'install',
+                                '--prefix', prefix, '--install-scripts', '{}/bin'.format(prefix)],
+                               cmd_dir=self.build_dir, env=self.env, logfile=self.logfile)

--- a/recipes/libass.recipe
+++ b/recipes/libass.recipe
@@ -17,6 +17,9 @@ class Recipe(recipe.Recipe):
         if self.config.target_platform == Platform.IOS and \
             self.config.target_arch in [Architecture.X86, Architecture.X86_64]:
             self.append_env('LDFLAGS', '-Wl,-read_only_relocs,suppress')
+        if self.config.target_platform == Platform.ANDROID and \
+            self.config.target_arch in [Architecture.X86, Architecture.X86_64]:
+            self.append_env('LDFLAGS', '-Wl,-z,notext')
         if self.config.target_platform in (Platform.WINDOWS, Platform.ANDROID):
             # Needed for codepage conversion support in subtitles
             self.deps.append('libiconv')

--- a/recipes/libgcrypt.recipe
+++ b/recipes/libgcrypt.recipe
@@ -13,3 +13,10 @@ class Recipe(recipe.Recipe):
     files_libs = ['libgcrypt']
     files_devel = ['include/gcrypt.h', 'bin/libgcrypt-config']
 
+    def prepare(self):
+        if self.config.cross_compiling() and \
+                self.config.target_platform == Platform.ANDROID and \
+                self.config.target_arch in (Architecture.X86, Architecture.X86_64):
+            # Fails linking with undefined symbols on function
+            # implemented in assembler, so disable those for now.
+            self.configure_options += ' --disable-asm'

--- a/recipes/libgpg-error.recipe
+++ b/recipes/libgpg-error.recipe
@@ -20,9 +20,9 @@ class Recipe(recipe.Recipe):
 
     async def configure(self):
         if self.config.cross_compiling():
-            if self.config.target_arch == Architecture.ARM64:
+            if self.config.target_arch in (Architecture.ARM64, Architecture.X86_64):
                 cfg_file = 'lock-obj-pub.aarch64-unknown-linux-gnu.h'
-            elif self.config.target_arch in (Architecture.ARM, Architecture.ARMv7):
+            elif self.config.target_arch in (Architecture.ARM, Architecture.ARMv7, Architecture.X86):
                 cfg_file = 'lock-obj-pub.arm-unknown-linux-androideabi.h'
             else:
                 raise FatalError('Unsupported target arch: ' + self.config.target_arch)

--- a/recipes/libpng.recipe
+++ b/recipes/libpng.recipe
@@ -22,5 +22,7 @@ class Recipe(recipe.Recipe):
             gas = self.get_env('GAS')
             if gas:
                 self.set_env('CCAS', gas, '-no-integrated-as')
+        elif self.config.target_platform == Platform.ANDROID:
+            self.append_env('CPPFLAGS', r' -I$$CERBERO_PREFIX/include')
         if self.config.target_arch == Architecture.ARM64:
             self.configure_options += ' --disable-arm-neon '

--- a/recipes/libwebp.recipe
+++ b/recipes/libwebp.recipe
@@ -8,11 +8,11 @@ from cerbero.utils import android
 
 class Recipe(recipe.Recipe):
     name = 'libwebp'
-    version = '1.2.0-rc3'
+    version = '1.2.2'
     stype = SourceType.TARBALL
     btype = BuildType.AUTOTOOLS
-    url = 'https://github.com/webmproject/libwebp/archive/v1.2.0-rc3.tar.gz'
-    tarball_checksum = '7505579ca0f290ad1847078c1e18f990c0ee5652aca7414687808382fe2d1223'
+    url = 'https://github.com/webmproject/libwebp/archive/v%(version)s.tar.gz'
+    tarball_checksum = '51e9297aadb7d9eb99129fe0050f53a11fcce38a0848fb2b0389e385ad93695e'
     allow_parallel_build = True
     autoreconf = True
 

--- a/recipes/openh264.recipe
+++ b/recipes/openh264.recipe
@@ -22,6 +22,11 @@ class Recipe(recipe.Recipe):
         name + "/0002-meson-Add-support-for-Windows-ARM-and-ARM64.patch",
     ]
 
+    def prepare(self):
+        if self.config.target_platform == Platform.ANDROID and \
+            self.config.target_arch in [Architecture.X86, Architecture.X86_64]:
+            self.append_env('LDFLAGS', '-Wl,-z,notext')
+
     def post_install(self):
         # XXX: Don't forget to keep this in sync with the library version!
         dependency_libs=[]

--- a/recipes/x264.recipe
+++ b/recipes/x264.recipe
@@ -59,6 +59,8 @@ class Recipe(recipe.Recipe):
                 # https://github.com/android-ndk/ndk/issues/690
                 # https://github.com/android-ndk/ndk/issues/693
                 enable_asm = False
+            if self.config.target_arch in [Architecture.X86, Architecture.X86_64]:
+                self.append_env('LDFLAGS', '-Wl,-z,notext')
 
         self.set_env('AS', *AS)
         if enable_asm is False:


### PR DESCRIPTION
This makes it possible to make builds of the `wpewebkit` packages for x86 and x86_64. This not only enabled more hardware support, but also allows faster development using the Android emulator without needing to take the slow path of emulating ARM hardware.

The changes introduced by the patch set are:

- Some more tweaks in `configs/android.cbc` were needed on top of those already done in #12 
- Switched the API level used in x86/x86_64 builds to 26 (Oreo, needed for `AHardwareBuffer`).
- Add `-Wl,-z,notext` to `LDFLAGS` in a few packages to avoid relocation errors at link time.
- Configure which lock internals `libgpg-error` should use, looking at the Bionic sources it looks to me that the definitions for x86 are the same as for ARMv7 (both 32-bit), and also the same for x86_64 and ARM64 (both 64-bit). To me this fix still feels a bit like like a quick and dirty hack, but seems to work for now.
- The `libwebp` package is updated to 1.2.2, which has a build fix for x86.
- Add a fix to make `libpng` pick the correct `zlib.h` header.
- Incorporate a fix from upstream for Meson packages.

Related: https://github.com/Igalia/wpe-android/issues/12