### PR TITLE
android: Remove __ANDROID_API__ definition from config

### DIFF
--- a/config/android.config
+++ b/config/android.config
@@ -129,7 +129,7 @@ if target_arch != Architecture.UNIVERSAL and not os.path.exists(lib_dir):
 # Most of the compiler/linker specific flags are taken from
 # from android-ndk-r16/build/core/toolchains/$NAME-$VERSION/setup.mk
 ccache = use_ccache and 'ccache ' or ''
-defines = '-DANDROID -DPIC -D__ANDROID_API__=%s ' % (v)
+defines = '-DANDROID -DPIC '
 # -target is being duplicated here and in CC variable to workaround cmake
 # ignoring arguments in CC while other build systems may ignore CFLAGS for
 # certain checks.

--- a/recipes/openssl.recipe
+++ b/recipes/openssl.recipe
@@ -53,7 +53,6 @@ class Recipe(recipe.Recipe):
                 return 'BSD-generic64'
             raise InvalidRecipeError(self, "Unknown iOS platform")
         if self.config.target_platform == Platform.ANDROID:
-            self.make += ['CROSS_SYSROOT=' + self.config.sysroot]
             if self.config.target_arch == Architecture.ARM:
                 return 'android-arm'
             if self.config.target_arch == Architecture.ARMv7:
@@ -199,6 +198,10 @@ class Recipe(recipe.Recipe):
                 config_sh += ' no-asm '
         else:
             config_sh += ' shared '
+
+        if self.config.target_platform == Platform.ANDROID:
+            api_version = DistroVersion.get_android_api_version(self.config.target_distro_version)
+            config_sh += f' -D__ANDROID_API__={api_version} '
 
         # ssl3 is needed by sphinx which is used by gst-validate, which tries
         # to use this libssl and fails with undefined symbols. md2 is needed by


### PR DESCRIPTION
Simplify the `android.cbc` configuration file by removing the manual definition of the `__ANDROID_API__` macro. This is nowadays defined by Clang automatically, and trying to redefine it from the command line results in compiler warning spam in compilation logs. Removing the manual definition is not only correct, it makes the logs more readable.

This needed also a tweak to the OpenSSL recipe: instead of being normal and using a proper build configuration system, its mess of a Perl script relies on `-D__ANDROID_API__=N` being set in `CPPFLAGS`, `CFLAGS`, or the script command line. The patch does the latter, and removes the definition of the `CROSS_SYSROOT` environment variable, which is also recommended in the [NOTES.ANDROID](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/NOTES.ANDROID#L65) file included in the OpenSSL source tree.