### PR TITLE
Handle ProcessLauncherGlib::platformInvalidate

### DIFF
--- a/recipes/wpewebkit.recipe
+++ b/recipes/wpewebkit.recipe
@@ -196,7 +196,8 @@ class Recipe(recipe.Recipe):
                 'wpewebkit/0011-Use-environment-variable-to-define-temp-folder-in-MediaPlayerPrivateGStreamer.patch',
                 'wpewebkit/0012-Enable-libwpe-process-management-API.patch',
                 'wpewebkit/0013-Use-ASharedMemory-instead-of-shm.patch',
-                'wpewebkit/0014-GTK-WPE-PlatformDisplay-terminateEglDisplays-is-neve.patch' # backport from webkit head
+                'wpewebkit/0014-GTK-WPE-PlatformDisplay-terminateEglDisplays-is-neve.patch', # backport from webkit head
+                'wpewebkit/0015-Call-WPEProcessProvider-kill-on-ProcessLauncher-plat.patch'
             ]
         else:
             self.append_env('LDFLAGS', '-lrt')

--- a/recipes/wpewebkit/0015-Call-WPEProcessProvider-kill-on-ProcessLauncher-plat.patch
+++ b/recipes/wpewebkit/0015-Call-WPEProcessProvider-kill-on-ProcessLauncher-plat.patch
@@ -1,0 +1,40 @@
+From 19fd633ef05956b50f134d76eafec90ecd7d2996 Mon Sep 17 00:00:00 2001
+From: Jani Hautakangas <jani@igalia.com>
+Date: Mon, 24 Oct 2022 18:11:05 +0300
+Subject: [PATCH] Call WPEProcessProvider::kill on
+ ProcessLauncher::platformInvalidate().
+
+It seems that platformInvalidate in most cases means that process should
+be killed. At least that is in case of android where auxiliary process
+is hosted by Android service. Maybe there should be another function
+for this in libwpe API but for now use kill() as it works correctly on
+Android.
+
+Note! It turned out that ProcessLauncher::terminateProcess() is almost
+never called by WebKit in real cases but process is killed before that
+call and it's actaully ProcessLauncher::platformInvalidate() that gets
+called.
+---
+ .../WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp  | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+index 83a683b6..67742150 100644
+--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
++++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+@@ -268,6 +268,12 @@ void ProcessLauncher::terminateProcess()
+ 
+ void ProcessLauncher::platformInvalidate()
+ {
++#if defined(WPE_ENABLE_PROCESS) && WPE_ENABLE_PROCESS
++    if (WPEProcessProvider::singleton().isEnabled() && m_processIdentifier > 0) {
++        WPEProcessProvider::singleton().kill(m_processIdentifier);
++        m_processIdentifier = 0;
++    }
++#endif
+ }
+ 
+ } // namespace WebKit
+-- 
+2.34.1
+


### PR DESCRIPTION
It seems that ProcessLauchnerGlib::terminateProcess is almost never called but ProcessLauncherGlib::platformInvalidate is called everytime webprocess is shutdown.
Add patch that forwards this call to libwpe process management API so Android glue can properly unbind hosting service