### PR TITLE
CI: Handle SSH host keys in upload script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,28 @@
 name: Build and Deploy
 on:
   workflow_dispatch:
+    inputs:
+      upload_packages:
+        description: 'Upload packages'
+        required: true
+        type: choice
+        default: 'on-merge'
+        options:
+          - 'on-merge'
+          - 'skip'
+          - 'yes'
   pull_request:
     types:
+      - opened
+      - synchronize
+      - reopened
       - closed
     branches:
       - 'wpe-android'
 
 jobs:
   build:
-    if: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/wpe-android') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
+    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
     runs-on: self-hosted
     strategy:
       matrix:
@@ -34,6 +47,7 @@ jobs:
           path: ./wpewebkit-android-${{ matrix.target }}*
           if-no-files-found: error
       - name: Upload packages to wpewebkit.org
+        if: ${{ inputs.upload_packages == 'yes' || (github.event.pull_request.merged == true && inputs.upload_packages == 'on-merge') }}
         run: |
           python3 ./.github/workflows/upload.py "./wpewebkit-android-${{ matrix.target }}*" || \
           echo "**:warning: WARNING :warning:** Cannot upload ./wpewebkit-android-${{ matrix.target }}... files to wpewebkit.org" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,4 @@ jobs:
           exit 0
         env:
           UPLOAD_KEY_PASSWD: ${{ secrets.UPLOAD_KEY_PASSWD }}
+          UPLOAD_SSH_KNOWN_HOSTS: ${{ secrets.UPLOAD_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
         default: 'on-merge'
         options:
           - 'on-merge'
+          - 'dry-run'
           - 'skip'
           - 'yes'
   pull_request:
@@ -47,11 +48,12 @@ jobs:
           path: ./wpewebkit-android-${{ matrix.target }}*
           if-no-files-found: error
       - name: Upload packages to wpewebkit.org
-        if: ${{ inputs.upload_packages == 'yes' || (github.event.pull_request.merged == true && inputs.upload_packages == 'on-merge') }}
+        if: ${{ inputs.upload_packages == 'yes' || inputs.upload_packages == 'dry-run' || (github.event.pull_request.merged == true && inputs.upload_packages == 'on-merge') }}
         run: |
           python3 ./.github/workflows/upload.py "./wpewebkit-android-${{ matrix.target }}*" || \
           echo "**:warning: WARNING :warning:** Cannot upload ./wpewebkit-android-${{ matrix.target }}... files to wpewebkit.org" >> $GITHUB_STEP_SUMMARY
           exit 0
         env:
+          UPLOAD_DRY_RUN: ${{ inputs.upload_packages == 'dry-run' }}
           UPLOAD_KEY_PASSWD: ${{ secrets.UPLOAD_KEY_PASSWD }}
           UPLOAD_SSH_KNOWN_HOSTS: ${{ secrets.UPLOAD_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/upload.py
+++ b/.github/workflows/upload.py
@@ -74,7 +74,9 @@ class PackageSpec:
 
 
 async def with_sftp(fn, *arg, **kw):
-    async with asyncssh.connect("wpewebkit.org", port=7575, username="www-data", passphrase=os.getenv("UPLOAD_KEY_PASSWD")) as conn:
+    async with asyncssh.connect("wpewebkit.org", port=7575, username="www-data",
+                                known_hosts=asyncssh.import_known_hosts(os.getenv("UPLOAD_SSH_KNOWN_HOSTS")),
+                                passphrase=os.getenv("UPLOAD_KEY_PASSWD")) as conn:
         async with conn.start_sftp_client() as sftp:
             return await fn(sftp, *arg, **kw)
 


### PR DESCRIPTION
Add a `known_hosts` option when opening SFTP connections in the upload script, to validate that the host we are connecting to is indeed the one we expect. The data in OpenSSH's `known_hosts` format is picked from the `UPLOAD_SSH_KNOWN_HOSTS` environment variable.